### PR TITLE
Fix ExaPF dependency on develop

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -17,8 +17,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
     # - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/Hiop.jl", rev="master")'
-      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="ms/cuda")'
-      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
+      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="develop")'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
 
@@ -38,7 +37,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
     # - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/Hiop.jl", rev="master")'
-      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="ms/cuda")'
-      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
+      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="develop")'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
     # - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/Hiop.jl", rev="master")'
-      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
       - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="develop")'
+      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
 
@@ -38,7 +38,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
     # - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/Hiop.jl", rev="master")'
-      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
       - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="develop")'
+      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
     # - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/Hiop.jl", rev="master")'
-      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="develop")'
+      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="ms/cuda")'
       - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
@@ -38,7 +38,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
     # - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/Hiop.jl", rev="master")'
-      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="develop")'
+      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="ms/cuda")'
       - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -18,6 +18,7 @@ jobs:
           version: ${{ matrix.julia-version }}
     # - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/Hiop.jl", rev="master")'
       - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
+      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="develop")'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
 
@@ -38,5 +39,6 @@ jobs:
           version: ${{ matrix.julia-version }}
     # - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/Hiop.jl", rev="master")'
       - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/sshin23/MadNLP.jl", rev="master")'
+      - run: julia --project -e 'using Pkg; Pkg.add(url="https://github.com/exanauts/ExaPF.jl", rev="develop")'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CUDA = "^3.0"
+CUDA = "~2, 3.0"
 CatViews = "1"
 ExaPF = "0.5"
 Ipopt = "0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CUDA = "^2.0"
+CUDA = "^3.0"
 CatViews = "1"
 ExaPF = "0.5"
 Ipopt = "0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CUDA = "~2, 3.0"
+CUDA = "~2.3, 3.0"
 CatViews = "1"
 ExaPF = "0.5"
 Ipopt = "0.6"


### PR DESCRIPTION
* Remove MadNLP `master` dependency and rely on release
* Point ExaPF dependency to `develop`
* Add CUDA 3.x support

Effectively, rely on development branches for ECP related packages and use releases for everything external.