### PR TITLE
Project.toml version bumps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,13 +17,13 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CUDA = "2, ~3.2"
+CUDA = "2, 3.2"
 CatViews = "1"
 ExaPF = "0.5"
 Ipopt = "0.6"
 JuMP = "0.21"
 MPI = "0.15"
-julia = "^1.5"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
* ExaTron and ExaPF now work with CUDA.jl 3.3
* @AnirudhSubramanyam reported that Julia 1.5 breaks with all dependencies so bumping Julia requirement to 1.6