### PR TITLE
Various version bumps

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.6']
+        julia-version: ['1.6', '1.7.0-beta4']
         julia-arch: [x64]
         os: [ubuntu-20.04]
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        julia-version: ['1.6']
+        julia-version: ['1.6', '1.7.0-beta4']
         julia-arch: [x64]
         os: [ubuntu-20.04]
 

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CUDA = "2, 3.2"
+CUDA = "3.4"
 CatViews = "1"
 ExaPF = "0.5"
 Ipopt = "0.6"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 
 # ProxAL.jl
 
-[![][docs-latest-img]][docs-latest-url] ![Run tests](https://github.com/exanauts/ProxAL.jl/workflows/Run%20tests/badge.svg?branch=master) 
+[![][docs-latest-img]][docs-latest-url] ![Run tests](https://github.com/exanauts/ProxAL.jl/workflows/Run%20tests/badge.svg?branch=master)
 
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://exanauts.github.io/ProxAL.jl/
 
 This is a Julia implementation of a parallel <ins>Prox</ins>imal <ins>A</ins>ugmented <ins>L</ins>agrangian solver for solving multiperiod contingency-constrained ACOPF problems. Please refer to the [documentation][docs-latest-url] for package installation, usage and solver options.
+
+# Installation
+
+The package is under heavy development and relies on non registered Julia packages and versions. This requires to install packages via
+
+```bash
+julia --project deps/deps.jl
+```


### PR DESCRIPTION
The same reasoning as for the other packages. We aggressively bump the versions (Julia 1.7, CUDA.jl 3.4) in anticipation for AMDGPU.jl, KA 0.7, avoiding ExprTools dependency bug in CUDA.jl, etc...