### PR TITLE
Convergence for contingencies

### DIFF
--- a/src/Evaluators/ProxALEvalutor.jl
+++ b/src/Evaluators/ProxALEvalutor.jl
@@ -115,12 +115,19 @@ function optimize!(nlp::ProxALEvaluator; print_timings=false)
         @views opt_sol[fr:to, blk] .= solution.va[:]
         # wt
         fr = to +1  ; to = fr + k_per_block -1
-        if !algparams.decompCtgs
-            @views opt_sol[fr:to, blk] .= solution.ωt[:]
-        end
+        @views opt_sol[fr:to, blk] .= solution.ωt[:]
         # St
         fr = to +1  ; to = fr + ngen - 1
         @views opt_sol[fr:to, blk] .= solution.st[:]
+        # zt
+        fr = to +1  ; to = fr + ngen -1
+        @views opt_sol[fr:to, blk] .= solution.zt[:]
+        # sk
+        fr = to +1  ; to = fr + ngen * k_per_block - 1
+        @views opt_sol[fr:to, blk] .= solution.sk[:]
+        # zk
+        fr = to +1  ; to = fr + ngen * k_per_block - 1
+        @views opt_sol[fr:to, blk] .= solution.zk[:]
     end
     #------------------------------------------------------------------------------------
     function blocknlp_copy(blk, x_ref, λ_ref, alg_ref)
@@ -310,10 +317,10 @@ function optimize!(nlp::ProxALEvaluator; print_timings=false)
             if algparams.updateρ_t
                 if runinfo.maxviol_t[end] > 10.0*runinfo.maxviol_d[end] && algparams.ρ_t < 32.0*algparams.θ_t
                     algparams.ρ_t = min(2.0*algparams.ρ_t, 32.0*algparams.θ_t)
-                    algparams.τ = 2.0*algparams.ρ_t
+                    algparams.τ = algparams.decompCtgs ? 2.0*max(algparams.ρ_t, algparams.ρ_c) : 2.0*algparams.ρ_t
                 elseif runinfo.maxviol_d[end] > 10.0*runinfo.maxviol_t[end]
                     algparams.ρ_t *= 0.5
-                    algparams.τ = 2.0*algparams.ρ_t
+                    algparams.τ = algparams.decompCtgs ? 2.0*max(algparams.ρ_t, algparams.ρ_c) : 2.0*algparams.ρ_t
                 end
             end
 

--- a/src/Evaluators/ProxALEvalutor.jl
+++ b/src/Evaluators/ProxALEvalutor.jl
@@ -48,9 +48,9 @@ function ProxALEvaluator(
         modelinfo.time_link_constr_type = :penalty
     end
     if modelinfo.num_ctgs > 1 && algparams.decompCtgs
-        if modelinfo.ctgs_link_constr_type ∉ [:frequency_ctrl, :preventive_penalty, :corrective_penalty]
+        if modelinfo.ctgs_link_constr_type ∉ [:frequency_penalty, :preventive_penalty, :corrective_penalty]
             str = "ProxAL is guaranteed to converge only when "*
-                  "ctgs_link_constr_type ∈ [:frequency_ctrl, :preventive_penalty, :corrective_penalty]\n"
+                  "ctgs_link_constr_type ∈ [:frequency_penalty, :preventive_penalty, :corrective_penalty]\n"
             if modelinfo.ctgs_link_constr_type == :preventive_equality
                 @warn(str * "         Forcing ctgs_link_constr_type = :preventive_penalty\n")
                 modelinfo.ctgs_link_constr_type = :preventive_penalty
@@ -58,8 +58,8 @@ function ProxALEvaluator(
                 @warn(str * "         Forcing ctgs_link_constr_type = :corrective_penalty\n")
                 modelinfo.ctgs_link_constr_type = :corrective_penalty
             else
-                @warn(str * "         Forcing ctgs_link_constr_type = :frequency_ctrl\n")
-                modelinfo.ctgs_link_constr_type = :frequency_ctrl
+                @warn(str * "         Forcing ctgs_link_constr_type = :frequency_penalty\n")
+                modelinfo.ctgs_link_constr_type = :frequency_penalty
             end
         end
     end
@@ -121,13 +121,19 @@ function optimize!(nlp::ProxALEvaluator; print_timings=false)
         @views opt_sol[fr:to, blk] .= solution.st[:]
         # zt
         fr = to +1  ; to = fr + ngen -1
-        @views opt_sol[fr:to, blk] .= solution.zt[:]
+        if haskey(solution, :zt)
+            @views opt_sol[fr:to, blk] .= solution.zt[:]
+        end
         # sk
         fr = to +1  ; to = fr + ngen * k_per_block - 1
-        @views opt_sol[fr:to, blk] .= solution.sk[:]
+        if haskey(solution, :sk)
+            @views opt_sol[fr:to, blk] .= solution.sk[:]
+        end
         # zk
         fr = to +1  ; to = fr + ngen * k_per_block - 1
-        @views opt_sol[fr:to, blk] .= solution.zk[:]
+        if haskey(solution, :zk)
+            @views opt_sol[fr:to, blk] .= solution.zk[:]
+        end
     end
     #------------------------------------------------------------------------------------
     function blocknlp_copy(blk, x_ref, λ_ref, alg_ref)

--- a/src/OPF/opfsolution.jl
+++ b/src/OPF/opfsolution.jl
@@ -112,18 +112,8 @@ function get_block_view(x::OPFPrimalSolution, block::CartesianIndex,
     Zt = view(x.Zt, :, t)
     Sk = view(x.Sk, :, range_k, t)
     Zk = view(x.Sk, :, range_k, t)
-    if modelinfo.allow_constr_infeas
-        sigma_real = view(x.sigma_real, :, range_k, t)
-        sigma_imag = view(x.sigma_imag, :, range_k, t)
-        sigma_lineFr = view(x.sigma_lineFr, :, range_k, t)
-        sigma_lineTo = view(x.sigma_lineTo, :, range_k, t)
 
-        solution = CatView(Pg, Qg, Vm, Va, ωt, St, Zt, Sk, Zk, sigma_real, sigma_imag, sigma_lineFr, sigma_lineTo)
-    else
-        solution = CatView(Pg, Qg, Vm, Va, ωt, St, Zt, Sk, Zk)
-    end
-
-    return solution
+    return CatView(Pg, Qg, Vm, Va, ωt, St, Zt, Sk, Zk)
 end
 
 function get_coupling_view(x::OPFPrimalSolution,
@@ -131,37 +121,6 @@ function get_coupling_view(x::OPFPrimalSolution,
                            algparams::AlgParams)
     Pg = @view x.Pg[:]
     return Pg
-    #=
-    ωt = @view x.ωt[:]
-    Zt = @view x.Zt[:]
-    Zk = @view x.Sk[:]
-
-    if algparams.decompCtgs
-        if modelinfo.time_link_constr_type == :penalty
-            if modelinfo.ctgs_link_constr_type == :frequency_ctrl
-                return CatView(Pg, ωt, Zt)
-            elseif modelinfo.ctgs_link_constr_type ∈ [:preventive_penalty, :corrective_penalty]
-                return CatView(Pg, Zt, Zk)
-            else
-                return CatView(Pg, Zt)
-            end
-        else
-            if modelinfo.ctgs_link_constr_type == :frequency_ctrl
-                return CatView(Pg, ωt)
-            elseif modelinfo.ctgs_link_constr_type ∈ [:preventive_penalty, :corrective_penalty]
-                return CatView(Pg, Zk)
-            else
-                return CatView(Pg)
-            end
-        end
-    else
-        if modelinfo.time_link_constr_type == :penalty
-            return CatView(Pg, Zt)
-        else
-            return CatView(Pg)
-        end
-    end
-    =#
 end
 
 function get_coupling_view(λ::OPFDualSolution,

--- a/src/ProxAL.jl
+++ b/src/ProxAL.jl
@@ -94,7 +94,9 @@ function update_primal_nlpvars(x::AbstractPrimalSolution, opfBlockData::Abstract
 
     from = 1+to
     to = to + size(x.St, 1)
-    @views x.St[:,t] .= opfBlockData.colValue[from:to,blk]
+    if !algparams.decompCtgs || k == 1
+        @views x.St[:,t] .= opfBlockData.colValue[from:to,blk]
+    end
 
     # Zt will be updated in update_primal_penalty
     from = 1+to
@@ -234,8 +236,8 @@ function ProxALProblem(
     blkLinIndex = LinearIndices(blocks.blkIndex)
     for blk in blkLinIndex
         if ismywork(blk, comm)
-            model = blocks.blkModel[blk]
-            init!(model, algparams)
+            # model = blocks.blkModel[blk]
+            # init!(model, algparams)
             blocks.colValue[:,blk] .= get_block_view(x, blocks.blkIndex[blk], modelinfo, algparams)
         end
     end

--- a/src/ProxAL.jl
+++ b/src/ProxAL.jl
@@ -88,9 +88,7 @@ function update_primal_nlpvars(x::AbstractPrimalSolution, opfBlockData::Abstract
 
     from = 1+to
     to = to + length(range_k)
-    if !algparams.decompCtgs
-        @views x.ωt[range_k,t] .= opfBlockData.colValue[from:to,blk]
-    end
+    @views x.ωt[range_k,t] .= opfBlockData.colValue[from:to,blk]
 
     from = 1+to
     to = to + size(x.St, 1)
@@ -106,7 +104,11 @@ function update_primal_nlpvars(x::AbstractPrimalSolution, opfBlockData::Abstract
     to = to + size(x.Sk, 1)*length(range_k)
     @views x.Sk[:,range_k,t][:] .= opfBlockData.colValue[from:to,blk]
 
-    # Zk will be updated in update_primal_penalty
+    from = 1+to
+    to = to + size(x.Zk, 1)*length(range_k)
+    if !algparams.decompCtgs
+        @views x.Zk[:,range_k,t][:] .= opfBlockData.colValue[from:to,blk]
+    end
 
     return nothing
 end
@@ -129,19 +131,12 @@ function update_primal_penalty(x::AbstractPrimalSolution, opfdata::OPFData,
                             ) ./  max(algparams.zero, (algparams.ρ_t/32.0) + algparams.ρ_t + (modelinfo.obj_scale*algparams.θ_t))
     end
     if k > 1 && algparams.decompCtgs
-        if modelinfo.ctgs_link_constr_type == :frequency_ctrl
-            x.ωt[k,t] = (( (algparams.ρ_c/32.0)*primal.ωt[k,t]) -
-                            sum(opfdata.generators[g].alpha *
-                                    (dual.ctgs[g,k,t] + (algparams.ρ_c * (x.Pg[g,1,t] - x.Pg[g,k,t])))
-                                for g=1:ngen)
-                        ) ./ max(algparams.zero, (algparams.ρ_c/32.0) + (modelinfo.obj_scale*modelinfo.weight_freq_ctrl) +
-                                sum(algparams.ρ_c*(opfdata.generators[g].alpha)^2
-                                    for g=1:ngen)
-                                )
-        end
-        if modelinfo.ctgs_link_constr_type ∈ [:preventive_penalty, :corrective_penalty]
+        if modelinfo.ctgs_link_constr_type ∈ [:frequency_penalty, :preventive_penalty, :corrective_penalty]
             if modelinfo.ctgs_link_constr_type == :corrective_penalty
                 β = [opfdata.generators[g].scen_agc for g=1:ngen]
+            elseif modelinfo.ctgs_link_constr_type == :frequency_penalty
+                β = [-opfdata.generators[g].alpha*x.ωt[k,t] for g=1:ngen]
+                @assert norm(x.Sk) <= algparams.zero
             else
                 β = zeros(ngen)
                 @assert norm(x.Sk) <= algparams.zero
@@ -182,7 +177,7 @@ function update_dual_vars(λ::AbstractDualSolution, opfdata::OPFData,
         maxviol_t = maximum(abs.(link_constr[:ramping][:]))
     end
     if k > 1 && algparams.decompCtgs
-        @assert modelinfo.ctgs_link_constr_type ∈ [:frequency_ctrl, :preventive_penalty, :corrective_penalty]
+        @assert modelinfo.ctgs_link_constr_type ∈ [:frequency_penalty, :preventive_penalty, :corrective_penalty]
         link_constr = compute_ctgs_linking_constraints(d, opfdata, modelinfo, k, t)
         λ.ctgs[:,k,t] += algparams.ρ_c*link_constr[:ctgs][:]
         maxviol_c = maximum(abs.(link_constr[:ctgs][:]))

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -244,6 +244,9 @@ function get_solution(block::JuMPBlockBackend)
         qg=JuMP.value.(opfmodel[:Qg]),
         ωt=JuMP.value.(opfmodel[:ωt]),
         st=JuMP.value.(opfmodel[:St]),
+        zt=JuMP.value.(opfmodel[:Zt]),
+        sk=JuMP.value.(opfmodel[:Sk]),
+        zk=JuMP.value.(opfmodel[:Zk]),
     )
     return solution
 end
@@ -262,7 +265,7 @@ end
 
 function add_variables!(block::JuMPBlockBackend, algparams::AlgParams)
     opf_model_add_variables(
-        block.model, block.data, block.params, algparams,
+        block.model, block.data, block.params, algparams, block.k, block.t
     )
 end
 

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -63,9 +63,7 @@ function OPFBlocks(
     blkCount = algparams.decompCtgs ? (T*K) : T
     blkIndex = algparams.decompCtgs ? CartesianIndices((1:K,1:T)) : CartesianIndices((1:1,1:T))
     colCount = ((algparams.decompCtgs ? 1 : K)*(
-                    2nbus + 4ngen + 1 +
-                        (Int(modelinfo.allow_constr_infeas)*(2nbus + 2nline))
-                )) + 2ngen
+                    2nbus + 4ngen + 1)) + 2ngen
     colValue = zeros(colCount,blkCount)
     blkModel = AbstractBlockModel[]
 

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -63,7 +63,7 @@ function OPFBlocks(
     blkCount = algparams.decompCtgs ? (T*K) : T
     blkIndex = algparams.decompCtgs ? CartesianIndices((1:K,1:T)) : CartesianIndices((1:1,1:T))
     colCount = ((algparams.decompCtgs ? 1 : K)*(
-                    2nbus + 4ngen + 1)) + 2ngen
+                    2*nbus + 4*ngen + 1)) + 2*ngen
     colValue = zeros(colCount,blkCount)
     blkModel = AbstractBlockModel[]
 

--- a/src/params.jl
+++ b/src/params.jl
@@ -97,7 +97,7 @@ Specifies the ACOPF model structure.
 | `case_name::String` | name of case file | ""
 | `savefile::String` | name of save file | ""
 | `time_link_constr_type::Symbol` | `∈ [:penalty, :equality, :inequality]` see [Formulation](@ref) | `:penalty`
-| `ctgs_link_constr_type::Symbol` | `∈ [:frequency_ctrl, :preventive_penalty, :preventive_equality, :corrective_penalty, :corrective_equality, :corrective_inequality]`, see [Formulation](@ref) | `:frequency_ctrl`
+| `ctgs_link_constr_type::Symbol` | `∈ [:frequency_penalty, :frequency_equality, :preventive_penalty, :preventive_equality, :corrective_penalty, :corrective_equality, :corrective_inequality]`, see [Formulation](@ref) | `:frequency_penalty`
 """
 Base.@kwdef mutable struct ModelInfo
     num_time_periods::Int = 1
@@ -113,5 +113,5 @@ Base.@kwdef mutable struct ModelInfo
     case_name::String = ""
     savefile::String = ""
     time_link_constr_type::Symbol = :penalty # ∈ [:penalty, :equality, :inequality]
-    ctgs_link_constr_type::Symbol = :frequency_ctrl # ∈ [:frequency_ctrl, :preventive_penalty, :preventive_equality, :corrective_penalty, :corrective_equality, :corrective_inequality]
+    ctgs_link_constr_type::Symbol = :frequency_penalty # ∈ [:frequency_penalty, :frequency_equality, :preventive_penalty, :preventive_equality, :corrective_penalty, :corrective_equality, :corrective_inequality]
 end

--- a/test/distributed.jl
+++ b/test/distributed.jl
@@ -28,7 +28,6 @@ modelinfo.ramp_scale = ramp_scale
 modelinfo.allow_obj_gencost = true
 modelinfo.allow_constr_infeas = false
 modelinfo.time_link_constr_type = :penalty
-modelinfo.ctgs_link_constr_type = :frequency_ctrl
 modelinfo.case_name = case
 modelinfo.num_ctgs = K
 

--- a/test/single.jl
+++ b/test/single.jl
@@ -28,7 +28,6 @@ modelinfo.allow_obj_gencost = true
 modelinfo.allow_constr_infeas = false
 modelinfo.weight_freq_ctrl = quad_penalty
 modelinfo.time_link_constr_type = :penalty
-modelinfo.ctgs_link_constr_type = :frequency_ctrl
 
 # Algorithm settings
 algparams = AlgParams()
@@ -109,7 +108,8 @@ end
 
             K = 1
             algparams.decompCtgs = false
-            @testset "$T-period, $K-ctgs, time_link=penalty, ctgs_link=frequency_ctrl" begin
+            modelinfo.ctgs_link_constr_type = :frequency_equality
+            @testset "$T-period, $K-ctgs, time_link=penalty, ctgs_link=frequency_equality" begin
                 modelinfo.num_ctgs = K
                 OPTIMAL_OBJVALUE = round(11258.316096601551*modelinfo.obj_scale, digits = 6)
                 OPTIMAL_PG = round.([0.8979870693416382, 1.3432060108971793, 0.9418738115511179, 0.9055318507524525, 1.3522597485901564, 0.9500221754747974, 0.9840203265549852, 1.4480400977338292, 1.014963889201792, 0.9932006221514175, 1.459056452449548, 1.024878608445939], digits = 5)
@@ -156,11 +156,11 @@ end
 
             K = 1
             algparams.decompCtgs = true
-            @testset "$T-period, $K-ctgs, time_link=penalty, ctgs_link=frequency_ctrl, decompCtgs" begin
+            modelinfo.ctgs_link_constr_type = :frequency_penalty
+            @testset "$T-period, $K-ctgs, time_link=penalty, ctgs_link=frequency_penalty, decompCtgs" begin
                 modelinfo.num_ctgs = K
                 OPTIMAL_OBJVALUE = round(11258.316096601551*modelinfo.obj_scale, digits = 6)
                 OPTIMAL_PG = round.([0.8979870693416382, 1.3432060108971793, 0.9418738115511179, 0.9055318507524525, 1.3522597485901564, 0.9500221754747974, 0.9840203265549852, 1.4480400977338292, 1.014963889201792, 0.9932006221514175, 1.459056452449548, 1.024878608445939], digits = 5)
-                OPTIMAL_WT = round.([0.0, -0.00012071650257302939, 0.0, -0.00014688472954291597], sigdigits = 4)
 
                 @testset "Non-decomposed formulation" begin
                     algparams.mode = :nondecomposed
@@ -170,7 +170,7 @@ end
                     @test isapprox(result["objective_value_nondecomposed"], OPTIMAL_OBJVALUE, rtol = rtol)
                     @test isapprox(result["primal"].Pg[:], OPTIMAL_PG, rtol = rtol)
                     @test norm(result["primal"].Zt[:], Inf) <= algparams.tol
-                    @test isapprox(result["primal"].ωt[:], OPTIMAL_WT, rtol = 1e-1)
+                    @test norm(result["primal"].Zk[:], Inf) <= algparams.tol
                 end
                 @testset "Lyapunov bound" begin
                     algparams.mode = :lyapunov_bound
@@ -185,14 +185,13 @@ end
                     algparams.mode = :coldstart
                     nlp = ProxALEvaluator(case_file, load_file, modelinfo, algparams, JuMPBackend(), Dict(), Dict(), nothing)
                     runinfo = ProxAL.optimize!(nlp)
-                    @test_broken isapprox(runinfo.objvalue[end], OPTIMAL_OBJVALUE, rtol = rtol)
-                    @test_broken isapprox(runinfo.x.Pg[:], OPTIMAL_PG, rtol = rtol)
-                    @test_broken isapprox(runinfo.x.ωt[:], OPTIMAL_WT, rtol = 1e-1)
-                    @test_broken runinfo.maxviol_c[end] <= algparams.tol
-                    @test_broken runinfo.maxviol_t[end] <= algparams.tol
-                    @test_broken runinfo.maxviol_c_actual[end] <= algparams.tol
-                    @test_broken runinfo.maxviol_t_actual[end] <= algparams.tol
-                    @test_broken runinfo.maxviol_d[end] <= algparams.tol
+                    @test isapprox(runinfo.objvalue[end], OPTIMAL_OBJVALUE, rtol = rtol)
+                    @test isapprox(runinfo.x.Pg[:], OPTIMAL_PG, rtol = 1e-2)
+                    @test runinfo.maxviol_c[end] <= algparams.tol
+                    @test runinfo.maxviol_t[end] <= algparams.tol
+                    @test runinfo.maxviol_c_actual[end] <= algparams.tol
+                    @test runinfo.maxviol_t_actual[end] <= algparams.tol
+                    @test runinfo.maxviol_d[end] <= algparams.tol
                     @test runinfo.iter <= algparams.iterlim
                 end
             end


### PR DESCRIPTION
This PR enables two important changes:
1. ProxAL now converges even with contingencies (that is, if `AlgParams.decompCtgs = true`). The old broken tests also pass in this case.
    * Among the different contingency linking constraints, `ModelInfo.ctgs_link_constr_type = :frequency_ctrl` has been removed since it is not guaranteed to converge in theory. It has been replaced with `ModelInfo.ctgs_link_constr_type = :frequency_penalty` which does converge in theory.
    * We need tests for the `ModelInfo.ctgs_link_constr_type = :preventive_penalty` and `ModelInfo.ctgs_link_constr_type = :corrective_penalty` formulations.
2. ProxAL now converges even when we allow the power balance and line flow constraints to be satisfied with some slack (that is, if `ModelInfo.allow_constr_infeas = true`). We don't have tests for this yet.