### PR TITLE
Multiperiod time series and ramping data input

### DIFF
--- a/examples/exatron.jl
+++ b/examples/exatron.jl
@@ -86,10 +86,6 @@ ranks = MPI.Comm_size(MPI.COMM_WORLD)
 if MPI.Comm_rank(MPI.COMM_WORLD) == 0
     println("ProxAL/ExaTron $ranks ranks, $T periods, $K contingencies")
 end
-# Tuple(genid, Pmin, Pmax)
-genOff = Dict{Int,Vector{Tuple{Int,Float64,Float64}}}()
-# At time period 2 switch generator 3 off by setting Pmin = Pmax = 0.0
-genOff[2] = [(3, 0.0, 0.0)]
 cur_logger = global_logger(NullLogger())
 elapsed_t = @elapsed begin
     # redirect_stdout(devnull) do
@@ -98,8 +94,7 @@ elapsed_t = @elapsed begin
         load_file,
         modelinfo,
         algparams,
-        backend;
-        genOff=genOff
+        backend
     )
     # end
 end

--- a/src/Evaluators/LinearizedProxALEvalutor.jl
+++ b/src/Evaluators/LinearizedProxALEvalutor.jl
@@ -1,4 +1,4 @@
-struct ProxALEvaluator <: AbstractNLPEvaluator
+struct LinearizedProxALEvaluator <: AbstractNLPEvaluator
     problem::ProxALProblem
     modelinfo::ModelInfo
     algparams::AlgParams
@@ -9,13 +9,13 @@ struct ProxALEvaluator <: AbstractNLPEvaluator
 end
 
 """
-    ProxALEvaluator(
+    LinearizedProxALEvaluator(
         case_file::String,
         load_file::String,
         modelinfo::ModelInfo,
         algparams::AlgParams,
-        space::AbstractBackend = JuMPBackend(),
-        comm::Union{MPI.Comm,Nothing} = MPI.COMM_WORLD
+        space::AbstractBackend=JuMPBackend(),
+        comm::MPI.Comm = MPI.COMM_WORLD
     )
 
 Instantiate multi-period ACOPF
@@ -24,23 +24,23 @@ specified in `case_file` with loads in `load_file` with model parameters
 a MPI communicator `comm`.
 
 """
-function ProxALEvaluator(
+function LinearizedProxALEvaluator(
     case_file::String,
     load_file::String,
     modelinfo::ModelInfo,
     algparams::AlgParams,
     space::AbstractBackend=JuMPBackend(),
-    comm::Union{MPI.Comm,Nothing} = MPI.COMM_WORLD;
-    genOff::Union{Dict{Int,Vector{Tuple{Int,Float64,Float64}}},Nothing} = nothing,
+    opt_sol::Dict = Dict(),
+    lyapunov_sol::Dict = Dict(),
+    comm::Union{MPI.Comm,Nothing} = MPI.COMM_WORLD
 )
     rawdata = RawData(case_file, load_file)
     opfdata = opf_loaddata(
         rawdata;
-        time_horizon_start = modelinfo.time_horizon_start,
-        time_horizon_end = modelinfo.time_horizon_start + modelinfo.num_time_periods - 1,
+        time_horizon_start = 1,
+        time_horizon_end = modelinfo.num_time_periods,
         load_scale = modelinfo.load_scale,
-        ramp_scale = modelinfo.ramp_scale,
-        corr_scale = modelinfo.corr_scale
+        ramp_scale = modelinfo.ramp_scale
     )
     if modelinfo.time_link_constr_type != :penalty
         @warn("ProxAL is guaranteed to converge only when time_link_constr_type = :penalty\n"*
@@ -48,9 +48,9 @@ function ProxALEvaluator(
         modelinfo.time_link_constr_type = :penalty
     end
     if modelinfo.num_ctgs > 1 && algparams.decompCtgs
-        if modelinfo.ctgs_link_constr_type ∉ [:frequency_penalty, :preventive_penalty, :corrective_penalty]
+        if modelinfo.ctgs_link_constr_type ∉ [:frequency_ctrl, :preventive_penalty, :corrective_penalty]
             str = "ProxAL is guaranteed to converge only when "*
-                  "ctgs_link_constr_type ∈ [:frequency_penalty, :preventive_penalty, :corrective_penalty]\n"
+                  "ctgs_link_constr_type ∈ [:frequency_ctrl, :preventive_penalty, :corrective_penalty]\n"
             if modelinfo.ctgs_link_constr_type == :preventive_equality
                 @warn(str * "         Forcing ctgs_link_constr_type = :preventive_penalty\n")
                 modelinfo.ctgs_link_constr_type = :preventive_penalty
@@ -58,15 +58,15 @@ function ProxALEvaluator(
                 @warn(str * "         Forcing ctgs_link_constr_type = :corrective_penalty\n")
                 modelinfo.ctgs_link_constr_type = :corrective_penalty
             else
-                @warn(str * "         Forcing ctgs_link_constr_type = :frequency_penalty\n")
-                modelinfo.ctgs_link_constr_type = :frequency_penalty
+                @warn(str * "         Forcing ctgs_link_constr_type = :frequency_ctrl\n")
+                modelinfo.ctgs_link_constr_type = :frequency_ctrl
             end
         end
     end
 
     # ctgs_arr = deepcopy(rawdata.ctgs_arr)
-    problem = ProxALProblem(opfdata, rawdata, modelinfo, algparams, space, comm; genOff=genOff)
-    return ProxALEvaluator(problem, modelinfo, algparams, opfdata, rawdata, space, comm)
+    problem = ProxALProblem(opfdata, rawdata, modelinfo, algparams, space, comm, opt_sol, lyapunov_sol)
+    return LinearizedProxALEvaluator(problem, modelinfo, algparams, opfdata, rawdata, space, comm)
 end
 
 """
@@ -76,38 +76,18 @@ Solve problem using the `nlp` evaluator
 of the decomposition algorithm.
 
 """
-function optimize!(
-    nlp::ProxALEvaluator;
-    print_timings::Bool=false,
-    θ_t_initial::Union{Real,Nothing}=nothing,
-    θ_c_initial::Union{Real,Nothing}=nothing,
-    ρ_t_initial::Union{Real,Nothing}=nothing,
-    ρ_c_initial::Union{Real,Nothing}=nothing,
-    τ_initial::Union{Real,Nothing}=nothing,
-    τ_factor::Float64 = 2.0
-)
+function optimize!(nlp::LinearizedProxALEvaluator; print_timings=false)
     algparams = nlp.algparams
     modelinfo = nlp.modelinfo
     runinfo   = nlp.problem
     opfdata   = nlp.opfdata
     comm      = nlp.comm
 
-    has_ctgs(modelinfo, algparams) = (algparams.decompCtgs && modelinfo.num_ctgs > 0)
-    maxρ(modelinfo, algparams) = has_ctgs(modelinfo, algparams) ? max(algparams.ρ_t, algparams.ρ_c) : algparams.ρ_t
-    τ_default(modelinfo, algparams) = τ_factor*maxρ(modelinfo, algparams)
-
     algparams.θ_t = algparams.θ_c = (1/algparams.tol^2)
     algparams.ρ_t = algparams.ρ_c = modelinfo.obj_scale
-    algparams.τ = τ_default(modelinfo, algparams)
-    !isnothing(θ_t_initial) && (algparams.θ_t = θ_t_initial)
-    !isnothing(θ_c_initial) && (algparams.θ_c = θ_c_initial)
-    !isnothing(ρ_t_initial) && (algparams.ρ_t = ρ_t_initial)
-    !isnothing(ρ_c_initial) && (algparams.ρ_c = ρ_c_initial)
-    !isnothing(τ_initial) && (algparams.τ = τ_initial)
-    if (!isnothing(ρ_t_initial) || !isnothing(ρ_c_initial)) && isnothing(τ_initial)
-        algparams.τ = τ_default(modelinfo, algparams)
-    end
-
+    algparams.τ = 2.0*max(algparams.ρ_t, algparams.ρ_c)
+    runinfo.initial_solve &&
+        (algparams_copy = deepcopy(algparams))
     opfBlockData = runinfo.opfBlockData
     nlp_opt_sol = runinfo.nlp_opt_sol
     nlp_soltime = runinfo.nlp_soltime
@@ -135,28 +115,15 @@ function optimize!(
         @views opt_sol[fr:to, blk] .= solution.va[:]
         # wt
         fr = to +1  ; to = fr + k_per_block -1
-        @views opt_sol[fr:to, blk] .= solution.ωt[:]
+        if !algparams.decompCtgs
+            @views opt_sol[fr:to, blk] .= solution.ωt[:]
+        end
         # St
         fr = to +1  ; to = fr + ngen - 1
         @views opt_sol[fr:to, blk] .= solution.st[:]
-        # zt
-        fr = to +1  ; to = fr + ngen -1
-        if haskey(solution, :zt)
-            @views opt_sol[fr:to, blk] .= solution.zt[:]
-        end
-        # sk
-        fr = to +1  ; to = fr + ngen * k_per_block - 1
-        if haskey(solution, :sk)
-            @views opt_sol[fr:to, blk] .= solution.sk[:]
-        end
-        # zk
-        fr = to +1  ; to = fr + ngen * k_per_block - 1
-        if haskey(solution, :zk)
-            @views opt_sol[fr:to, blk] .= solution.zk[:]
-        end
     end
     #------------------------------------------------------------------------------------
-    function blocknlp_optimize(blk, x_ref, λ_ref, alg_ref)
+    function blocknlp_copy(blk, x_ref, λ_ref, alg_ref)
         model = opfBlockData.blkModel[blk]
         # Update objective
         set_objective!(model, alg_ref, x_ref, λ_ref)
@@ -165,11 +132,15 @@ function optimize!(
         transfer!(blk, nlp_opt_sol, solution)
     end
     #------------------------------------------------------------------------------------
-    function blocknlp_init_and_optimize(blk, x_ref, λ_ref, alg_ref)
+    function blocknlp_recreate(blk, x_ref, λ_ref, alg_ref)
         model = opfBlockData.blkModel[blk]
         init!(model, alg_ref)
         # Update objective
-        set_objective!(model, alg_ref, x_ref, λ_ref)
+        obj_expr = compute_objective_function(model.model, model.data, model.params, alg_ref, model.k, model.t)
+        auglag_penalty = opf_block_get_auglag_penalty_expr_linearized(
+            model.model, model.params, model.data, model.k, model.t, alg_ref, x_ref, λ_ref)
+        @objective(model.model, Min, obj_expr + auglag_penalty)
+        #
         x0 = @view opfBlockData.colValue[:, blk]
         solution = optimize!(model, x0, alg_ref)
         transfer!(blk, nlp_opt_sol, solution)
@@ -180,11 +151,11 @@ function optimize!(
             # Primal update except penalty vars
             nlp_soltime .= 0.0
             nlp_soltime_local = 0.0
-            for blk in runinfo.blkLinIndex
-                if is_my_work(blk, comm)
+            for blk in runinfo.par_order
+                if ismywork(blk, comm)
                     nlp_opt_sol[:,blk] .= 0.0
-                    nlp_soltime[blk] = @elapsed blocknlp_optimize(blk, x, λ, algparams)
-                    # nlp_soltime[blk] = @elapsed blocknlp_init_and_optimize(blk, x, λ, algparams)
+                    # nlp_soltime[blk] = @elapsed blocknlp_copy(blk; x_ref = x, λ_ref = λ, alg_ref = algparams)
+                    nlp_soltime[blk] = @elapsed blocknlp_recreate(blk, x, λ, algparams)
                     nlp_soltime_local += nlp_soltime[blk]
                 end
             end
@@ -194,7 +165,7 @@ function optimize!(
 
             print_timings && comm_barrier(comm)
             elapsed_t = @elapsed begin
-                requests = comm_neighbors!(nlp_opt_sol, opfBlockData, runinfo, CommPatternTK(), comm)
+                requests = comm_neighbors!(nlp_opt_sol, opfBlockData, runinfo, comm)
                 # Every worker sends his contribution
                 comm_sum!(nlp_soltime, comm)
                 comm_wait!(requests)
@@ -206,20 +177,20 @@ function optimize!(
 
             # Update primal values
             elapsed_t = @elapsed begin
-                for blk in runinfo.blkLinIndex
+                for blk in runinfo.par_order
                     block = opfBlockData.blkIndex[blk]
                     k = block[1]
                     t = block[2]
-                    if is_my_work(blk, comm)
+                    if ismywork(blk, comm)
                         # Updating my own primal values
                         opfBlockData.colValue[:,blk] .= nlp_opt_sol[:,blk]
                         update_primal_nlpvars(x, opfBlockData, blk, modelinfo, algparams)
-                        for blkn in runinfo.blkLinIndex
+                        for blkn in runinfo.par_order
                             blockn = opfBlockData.blkIndex[blkn]
                             kn = blockn[1]
                             tn = blockn[2]
                             # Updating the received neighboring primal values
-                            if is_comm_pattern(t, tn, k, kn, CommPatternTK()) && !is_my_work(blkn, comm)
+                            if (tn == t-1 || tn == t+1) && !ismywork(blkn, comm)
                                 opfBlockData.colValue[:,blkn] .= nlp_opt_sol[:,blkn]
                                 update_primal_nlpvars(x, opfBlockData, blkn, modelinfo, algparams)
                             end
@@ -236,8 +207,8 @@ function optimize!(
 
             # Primal update of penalty vars
             elapsed_t = @elapsed begin
-                for blk in runinfo.blkLinIndex
-                    if is_my_work(blk, comm)
+                for blk in runinfo.par_order
+                    if ismywork(blk, comm)
                         update_primal_penalty(x, opfdata, opfBlockData, blk, x, λ, modelinfo, algparams)
                     end
                 end
@@ -250,29 +221,25 @@ function optimize!(
 
         print_timings && comm_barrier(comm)
         elapsed_t = @elapsed begin
-            requests_zt = comm_neighbors!(x.Zt, opfBlockData, runinfo, CommPatternT(), comm)
-            if algparams.decompCtgs
-                requests_zk = comm_neighbors!(x.Zk, opfBlockData, runinfo, CommPatternK(), comm)
-                comm_wait!(requests_zk)
-            end
-            comm_wait!(requests_zt)
+            requests = comm_neighbors!(x.Zt, opfBlockData, runinfo, comm)
+            comm_wait!(requests)
             print_timings && comm_barrier(comm)
         end
         if comm_rank(comm) == 0
             print_timings && println("Comm penalty: $elapsed_t")
         end
-        runinfo.wall_time_elapsed_ideal += isempty(runinfo.blkLinIndex) ? 0.0 : maximum([nlp_soltime[blk] for blk in runinfo.blkLinIndex])
+        runinfo.wall_time_elapsed_ideal += isempty(runinfo.par_order) ? 0.0 : maximum([nlp_soltime[blk] for blk in runinfo.par_order])
         runinfo.wall_time_elapsed_ideal += elapsed_t
     end
     #------------------------------------------------------------------------------------
     function dual_update()
         elapsed_t = @elapsed begin
             maxviol_t = 0.0; maxviol_c = 0.0
-            for blk in runinfo.blkLinIndex
+            for blk in runinfo.par_order
                 block = opfBlockData.blkIndex[blk]
                 k = block[1]
                 t = block[2]
-                if is_my_work(blk, comm)
+                if ismywork(blk, comm)
                     lmaxviol_t, lmaxviol_c = update_dual_vars(λ, opfdata, opfBlockData, blk, x, modelinfo, algparams)
                     maxviol_t = max(maxviol_t, lmaxviol_t)
                     maxviol_c = max(maxviol_c, lmaxviol_c)
@@ -284,16 +251,12 @@ function optimize!(
           print_timings && println("update_dual_vars(): $elapsed_t")
         end
         elapsed_t = @elapsed begin
-            requests_ramp = comm_neighbors!(λ.ramping, opfBlockData, runinfo, CommPatternT(), comm)
-            if algparams.decompCtgs
-                requests_ctgs = comm_neighbors!(λ.ctgs, opfBlockData, runinfo, CommPatternK(), comm)
-                comm_wait!(requests_ctgs)
-            end
-            comm_wait!(requests_ramp)
+            requests = comm_neighbors!(λ.ramping, opfBlockData, runinfo, comm)
             maxviol_t = comm_max(maxviol_t, comm)
             maxviol_c = comm_max(maxviol_c, comm)
             push!(runinfo.maxviol_t, maxviol_t)
             push!(runinfo.maxviol_c, maxviol_c)
+            comm_wait!(requests)
             print_timings && comm_barrier(comm)
         end
         if comm_rank(comm) == 0
@@ -306,8 +269,9 @@ function optimize!(
     function proximal_parameter_update()
         elapsed_t = @elapsed begin
             if algparams.updateτ && runinfo.iter > 1
+                maxθ = algparams.decompCtgs  ? max(algparams.θ_t, algparams.θ_c) : algparams.θ_t
                 delta = (runinfo.lyapunov[end-1] - runinfo.lyapunov[end])/abs(runinfo.lyapunov[end])
-                if delta < -1e-4 && algparams.τ < ((2*k_per_block*T) - 1)*maxρ(modelinfo, algparams)
+                if delta < -1e-4 && algparams.τ < 320.0*maxθ
                     algparams.τ *= 2.0
                 end
             end
@@ -350,10 +314,10 @@ function optimize!(
             if algparams.updateρ_t
                 if runinfo.maxviol_t[end] > 10.0*runinfo.maxviol_d[end] && algparams.ρ_t < 32.0*algparams.θ_t
                     algparams.ρ_t = min(2.0*algparams.ρ_t, 32.0*algparams.θ_t)
-                    algparams.τ = τ_default(modelinfo, algparams)
+                    algparams.τ = 2.0*algparams.ρ_t
                 elseif runinfo.maxviol_d[end] > 10.0*runinfo.maxviol_t[end]
                     algparams.ρ_t *= 0.5
-                    algparams.τ = τ_default(modelinfo, algparams)
+                    algparams.τ = 2.0*algparams.ρ_t
                 end
             end
 
@@ -362,10 +326,10 @@ function optimize!(
                 @info "tau-update not finalized when decompCtgs = true" maxlog=1
                 if runinfo.maxviol_c[end] > 10.0*runinfo.maxviol_d[end] && algparams.ρ_c < 32.0*algparams.θ_c
                     algparams.ρ_c = min(2.0*algparams.ρ_c, 32.0*algparams.θ_c)
-                    algparams.τ = τ_default(modelinfo, algparams)
+                    algparams.τ = 2.0*max(algparams.ρ_t, algparams.ρ_c)
                 elseif runinfo.maxviol_d[end] > 10*runinfo.maxviol_c[end]
                     algparams.ρ_c *= 0.5
-                    algparams.τ = τ_default(modelinfo, algparams)
+                    algparams.τ = 2.0*max(algparams.ρ_t, algparams.ρ_c)
                 end
             end
         end
@@ -377,6 +341,16 @@ function optimize!(
     algparams.init_opf && opf_initialization!(nlp)
 
     function iteration()
+
+        if runinfo.initial_solve
+            if runinfo.iter == 1
+                algparams.ρ_t = 0.0
+                algparams.ρ_c = 0.0
+                algparams.τ = 0.0
+            elseif runinfo.iter == 2
+                algparams = deepcopy(algparams_copy)
+            end
+        end
 
         # use this to compute the KKT error at the end of the loop
         runinfo.xprev = deepcopy(x)
@@ -419,7 +393,7 @@ function optimize!(
     return runinfo
 end
 
-function opf_initialization!(nlp::ProxALEvaluator)
+function opf_initialization!(nlp::LinearizedProxALEvaluator)
     runinfo   = nlp.problem
     modelinfo = nlp.modelinfo
     opfdata   = nlp.opfdata

--- a/src/Evaluators/NonDecomposedModel.jl
+++ b/src/Evaluators/NonDecomposedModel.jl
@@ -14,14 +14,11 @@ end
         modelinfo::ModelInfo,
         algparams::AlgParams,
         space::AbstractBackend=JuMPBackend(),
-        time_horizon_start = 1,
     )
 
 Instantiate non-decomposed multi-period ACOPF instance
 specified in `case_file` with loads in `load_file` with model parameters
 `modelinfo` and algorithm parameters `algparams`.
-The problem is defined over the horizon
-[`time_horizon_start`, `modelinfo.num_time_periods`]
 
 """
 function NonDecomposedModel(
@@ -29,13 +26,12 @@ function NonDecomposedModel(
     modelinfo::ModelInfo,
     algparams::AlgParams,
     space::AbstractBackend=JuMPBackend(),
-    time_horizon_start=1
 )
     rawdata = RawData(case_file, load_file)
     opfdata = opf_loaddata(
         rawdata;
-        time_horizon_start = time_horizon_start,
-        time_horizon_end = modelinfo.num_time_periods,
+        time_horizon_start = modelinfo.time_horizon_start,
+        time_horizon_end = modelinfo.time_horizon_start + modelinfo.num_time_periods - 1,
         load_scale = modelinfo.load_scale,
         ramp_scale = modelinfo.ramp_scale,
         corr_scale = modelinfo.corr_scale

--- a/src/Evaluators/ProxALEvalutor.jl
+++ b/src/Evaluators/ProxALEvalutor.jl
@@ -30,8 +30,7 @@ function ProxALEvaluator(
     modelinfo::ModelInfo,
     algparams::AlgParams,
     space::AbstractBackend=JuMPBackend(),
-    comm::Union{MPI.Comm,Nothing} = MPI.COMM_WORLD;
-    genOff::Union{Dict{Int,Vector{Tuple{Int,Float64,Float64}}},Nothing} = nothing,
+    comm::Union{MPI.Comm,Nothing} = MPI.COMM_WORLD
 )
     rawdata = RawData(case_file, load_file)
     opfdata = opf_loaddata(
@@ -65,7 +64,7 @@ function ProxALEvaluator(
     end
 
     # ctgs_arr = deepcopy(rawdata.ctgs_arr)
-    problem = ProxALProblem(opfdata, rawdata, modelinfo, algparams, space, comm; genOff=genOff)
+    problem = ProxALProblem(opfdata, rawdata, modelinfo, algparams, space, comm)
     return ProxALEvaluator(problem, modelinfo, algparams, opfdata, rawdata, space, comm)
 end
 

--- a/src/Evaluators/ProxALEvalutor.jl
+++ b/src/Evaluators/ProxALEvalutor.jl
@@ -383,7 +383,9 @@ function optimize!(
         runinfo.λprev = deepcopy(λ)
 
         # Primal update
-        primal_update()
+        for _ in 1:algparams.num_sweeps
+            primal_update()
+        end
 
         # Dual update
         dual_update()

--- a/src/OPF/opfdata.jl
+++ b/src/OPF/opfdata.jl
@@ -204,7 +204,7 @@ Loads the multi-period ACOPF instance data from `raw`
 with the time horizon defined to be
 [`time_horizon_start`,  `time_horizon_end`].
 Note that `time_horizon_end = 0` indicates as many
-as possible (the number of columns in `raw.pd_arr`).
+as possible (the number of columns in `raw.pd_arr` minus `time_horizon_start - 1`).
 
 All loads in all time periods will be multiplied by `load_scale`.
 The `ramp_scale` is the factor which multiplies the ramp rate
@@ -427,6 +427,9 @@ function opf_loaddata(raw::RawData;
         end
         Pd = Pd[:,time_horizon_start:time_horizon_end] .* load_scale
         Qd = Qd[:,time_horizon_start:time_horizon_end] .* load_scale
+    else
+        Pd = Pd[:,time_horizon_start:end] .* load_scale
+        Qd = Qd[:,time_horizon_start:end] .* load_scale
     end
 
     # Pgmax for multiperiod renewable data
@@ -441,7 +444,7 @@ function opf_loaddata(raw::RawData;
             end
         else
             for (i, git) in enumerate(gens_on)
-                Pgmax[i, :] .= raw.pgmax_arr[git, :] ./ baseMVA
+                Pgmax[i, :] .= raw.pgmax_arr[git, time_horizon_start:end] ./ baseMVA
             end
         end
     end

--- a/src/OPF/opfdata.jl
+++ b/src/OPF/opfdata.jl
@@ -22,14 +22,15 @@ function parse_file(datafile)
     if endswith(datafile, ".raw")
         data_raw = ParsePSSE.parse_raw(datafile)
         data = ParsePSSE.raw_to_exapf(data_raw)
+        return data_raw, data
     elseif endswith(datafile, ".m")
         data_mat = ParseMAT.parse_mat(datafile)
         data = ParseMAT.mat_to_exapf(data_mat)
+        return data_mat, data
     else
         error("Unsupported format in file $(datafile): supported extensions are " *
               "Matpower (.m) or PSSE (.raw)")
     end
-    return data
 end
 
 struct Bus
@@ -106,6 +107,7 @@ struct OPFData
     BusGenerators::Dict{Int, Array{Int}}     #list of generators for each bus (Array of Array)
     Pd::Array                #2d array of active power demands over a time horizon
     Qd::Array                #2d array of reactive power demands
+    Pgmax::Array             #2d array of maximum possible active generation over a time horizon
 end
 
 
@@ -119,8 +121,10 @@ Specifies the ACOPF instance data.
 - `branch_arr`: imported with ExaPF parser
 - `gen_arr`: imported with ExaPF parser
 - `costgen_arr`: imported with ExaPF parser
+- `genfuel_arr`: imported with ExaPF parser
 - `pd_arr`: read from `.Pd` file
 - `qd_arr`: read from `.Qd` file
+- `pgmax_arr`: read from `.Pgmax` file
 - `ctgs_arr`: read from `.Ctgs` file
 """
 mutable struct RawData
@@ -129,8 +133,10 @@ mutable struct RawData
     branch_arr::Array{Float64, 2}
     gen_arr::Array{Float64, 2}
     costgen_arr::Array{Float64, 2}
+    genfuel_arr::Vector{String}
     pd_arr::Array{Float64, 2}
     qd_arr::Array{Float64, 2}
+    pgmax_arr::Array{Float64, 2}
     ctgs_arr
 end
 
@@ -142,7 +148,7 @@ end
 ##
 
 function RawData(case_name, scen_file::String="")
-    data = parse_file(case_name)
+    data_mat, data = parse_file(case_name)
     bus_arr = data["bus"]
     branch_arr = data["branch"]
     gen_arr = data["gen"]
@@ -154,18 +160,26 @@ function RawData(case_name, scen_file::String="")
 
     pd_arr = Array{Float64, 2}(undef, 0, 0)
     qd_arr = Array{Float64, 2}(undef, 0, 0)
+    pgmax_arr = Array{Float64, 2}(undef, 0, 0)
     ctgs_arr = Array{Int64, 2}(undef, 0, 0)
+    genfuel_arr = Vector{String}(undef, size(gen_arr, 1))
 
+    if haskey(data_mat, "genfuel")
+        genfuel_arr .= [data_mat["genfuel"][i]["col_1"] for i in 1:size(gen_arr, 1)]
+    end
     if isfile(scen_file * ".Pd")
         pd_arr = readdlm(scen_file * ".Pd")
     end
     if isfile(scen_file * ".Qd")
         qd_arr = readdlm(scen_file * ".Qd")
     end
+    if isfile(scen_file * ".Pgmax")
+        pgmax_arr = readdlm(scen_file * ".Pgmax")
+    end
     if isfile(scen_file * ".Ctgs")
         ctgs_arr = readdlm(scen_file * ".Ctgs", Int)
     end
-    return RawData(baseMVA, bus_arr, branch_arr, gen_arr, costgen_arr, pd_arr, qd_arr, ctgs_arr)
+    return RawData(baseMVA, bus_arr, branch_arr, gen_arr, costgen_arr, genfuel_arr, pd_arr, qd_arr, pgmax_arr, ctgs_arr)
 end
 
 # UTILS
@@ -193,14 +207,28 @@ Note that `time_horizon_end = 0` indicates as many
 as possible (the number of columns in `raw.pd_arr`).
 
 All loads in all time periods will be multiplied by `load_scale`.
-The `ramp_scale` is the factor which multiplies ``p_{g}^{max}``
-to get generator ramping ``r_g``.
+The `ramp_scale` is the factor which multiplies the ramp rate
+to get generator ramping ``r_g`` (see NOTE below).
 The `corr_scale` is the factor which multiplies ``r_g``
 to get generator ramping for corrective control.
 These are set in `ModelInfo`.  See [Model parameters](@ref).
 
 `lineOff` is a transmission line that can be deleted to
 represent a contingency.
+
+NOTE: If `raw.genfuel_arr` is undefined for generator ``g``,
+then the ramp rate is set equal to ``p_{g}^{max}``.
+Otherwise, the ramp rate is set based on the genfuel type as follows.
+    coal => 3
+    wind => 45
+    solar => 200
+    ng => 35
+    nuclear => 20
+    hydro => 150
+    default => 3 (same as coal)
+
+All values in MW/min. Taken from:
+https://www.researchgate.net/post/What_is_the_typical_MW_minute_ramping_capability_for_each_type_of_reserve
 """
 function opf_loaddata(raw::RawData;
                       time_horizon_start::Int=1,
@@ -278,6 +306,7 @@ function opf_loaddata(raw::RawData;
     #
     gen_arr = raw.gen_arr
     costgen_arr = raw.costgen_arr
+    genfuel_arr = raw.genfuel_arr
     num_gens = size(gen_arr, 1)
     ncols_gens = size(gen_arr, 2)
 
@@ -291,6 +320,14 @@ function opf_loaddata(raw::RawData;
     baseMVA = raw.baseMVA
     generators = Array{Gener}(undef, num_on)
     R = 0.04 # Droop regulation
+    default_ramp_rate = Dict(
+        "coal" => 3.0,
+        "wind" => 45.0,
+        "solar" => 200.0,
+        "ng" => 35.0,
+        "nuclear" => 20.0,
+        "hydro" => 150.0,
+    )
     for (i, git) in enumerate(gens_on)
 
         generators[i] = Gener(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,Array{Int}(undef, 0),0)
@@ -348,6 +385,16 @@ function opf_loaddata(raw::RawData;
                 error("Invalid generator cost model in the data.")
             end
         end
+        if isassigned(genfuel_arr, git)
+            generators[i].ramp_agc = get(default_ramp_rate, genfuel_arr[git], default_ramp_rate["coal"]) * ramp_scale / baseMVA
+            generators[i].scen_agc = generators[i].ramp_agc * corr_scale
+            if genfuel_arr[git] ∈ ["wind", "solar"]
+                generators[i].Pmin = 0
+            end
+        end
+        if size(raw.pgmax_arr, 1) > 0 && time_horizon_start == time_horizon_end
+            generators[i].Pmax = raw.pgmax_arr[git, time_horizon_start] / baseMVA
+        end
     end
 
     # build a dictionary between buses ids and their indexes
@@ -382,7 +429,24 @@ function opf_loaddata(raw::RawData;
         Qd = Qd[:,time_horizon_start:time_horizon_end] .* load_scale
     end
 
-    return OPFData(buses, lines, generators, bus_ref, baseMVA, Ybus, busIdx, BusGeners, Pd, Qd)
+    # Pgmax for multiperiod renewable data
+    Pgmax = zeros(num_on, size(Pd, 2))
+    for i in 1:num_on
+        Pgmax[i, :] .= generators[i].Pmax
+    end
+    if size(raw.pgmax_arr, 1) > 0
+        if time_horizon_end > 0
+            for (i, git) in enumerate(gens_on)
+                Pgmax[i, :] .= raw.pgmax_arr[git, time_horizon_start:time_horizon_end] ./ baseMVA
+            end
+        else
+            for (i, git) in enumerate(gens_on)
+                Pgmax[i, :] .= raw.pgmax_arr[git, :] ./ baseMVA
+            end
+        end
+    end
+
+    return OPFData(buses, lines, generators, bus_ref, baseMVA, Ybus, busIdx, BusGeners, Pd, Qd, Pgmax)
 end
 
 function computeAdmitances(lines, buses, baseMVA; lossless::Bool=false, fixedtaps::Bool=false, zeroshunts::Bool=false)

--- a/src/OPF/opfmodel.jl
+++ b/src/OPF/opfmodel.jl
@@ -113,8 +113,8 @@ function opf_model_add_block_constraints(opfmodel::JuMP.Model, opfdata::OPFData,
             opfdata_c = (k == 1) ? opfdata :
                 opf_loaddata(rawdata;
                     lineOff = opfdata.lines[rawdata.ctgs_arr[k - 1]],
-                    time_horizon_start = t,
-                    time_horizon_end = t,
+                    time_horizon_start = modelinfo.time_horizon_start + t - 1,
+                    time_horizon_end = modelinfo.time_horizon_start + t - 1,
                     load_scale = modelinfo.load_scale,
                     ramp_scale = modelinfo.ramp_scale,
                     corr_scale = modelinfo.corr_scale)
@@ -131,8 +131,8 @@ function opf_model_add_block_constraints(opfmodel::JuMP.Model, opfdata::OPFData,
             opfdata_c = (k == 1) ? opfdata :
                 opf_loaddata(rawdata;
                     lineOff = opfdata.lines[rawdata.ctgs_arr[k - 1]],
-                    time_horizon_start = t,
-                    time_horizon_end = t,
+                    time_horizon_start = modelinfo.time_horizon_start + t - 1,
+                    time_horizon_end = modelinfo.time_horizon_start + t - 1,
                     load_scale = modelinfo.load_scale,
                     ramp_scale = modelinfo.ramp_scale,
                     corr_scale = modelinfo.corr_scale)

--- a/src/OPF/opfmodel.jl
+++ b/src/OPF/opfmodel.jl
@@ -39,6 +39,12 @@ function opf_model_add_variables(opfmodel::JuMP.Model, opfdata::OPFData,
         set_lower_bound.(Pg[i,:,:], gens[i].Pmin)
         set_upper_bound.(Pg[i,:,:], gens[i].Pmax)
         set_start_value.(Pg[i,:,:], 0.5*(gens[i].Pmax + gens[i].Pmin))
+        if tIdx == 0
+            for t=1:T
+                set_upper_bound.(Pg[i,:,t], opfdata.Pgmax[i,t])
+                set_start_value.(Pg[i,:,t], 0.5*(opfdata.Pgmax[i,t] + gens[i].Pmin))
+            end
+        end
         set_lower_bound.(Qg[i,:,:], gens[i].Qmin)
         set_upper_bound.(Qg[i,:,:], gens[i].Qmax)
         set_start_value.(Qg[i,:,:], 0.5*(gens[i].Qmax + gens[i].Qmin))

--- a/src/ProxAL.jl
+++ b/src/ProxAL.jl
@@ -202,8 +202,7 @@ function ProxALProblem(
     modelinfo::ModelInfo,
     algparams::AlgParams,
     backend::AbstractBackend,
-    comm::Union{MPI.Comm,Nothing};
-    genOff::Union{Dict{Int,Vector{Tuple{Int,Float64,Float64}}},Nothing} = nothing,
+    comm::Union{MPI.Comm,Nothing}
 )
     # initial values
     x = OPFPrimalSolution(opfdata, modelinfo)
@@ -219,7 +218,7 @@ function ProxALProblem(
     blocks = OPFBlocks(
         opfdata, rawdata;
         modelinfo=modelinfo, algparams=algparams,
-        backend=backend, comm, genOff=genOff,
+        backend=backend, comm=comm
     )
     blkLinIndex = LinearIndices(blocks.blkIndex)
     for blk in blkLinIndex

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -211,8 +211,8 @@ function init!(block::JuMPBlockBackend, algparams::AlgParams)
         opfdata_c = (j == 1) ? opfdata :
             opf_loaddata(block.rawdata;
             lineOff = opfdata.lines[block.rawdata.ctgs_arr[j - 1]],
-            time_horizon_start = t,
-            time_horizon_end = t,
+            time_horizon_start = modelinfo.time_horizon_start + t - 1,
+            time_horizon_end = modelinfo.time_horizon_start + t - 1,
             load_scale = modelinfo.load_scale,
             ramp_scale = modelinfo.ramp_scale,
             corr_scale = modelinfo.corr_scale)

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -93,8 +93,8 @@ function OPFBlocks(
         end
         data = opf_loaddata(
             rawdata;
-            time_horizon_start=t,
-            time_horizon_end=t,
+            time_horizon_start=modelinfo.time_horizon_start + t - 1,
+            time_horizon_end=modelinfo.time_horizon_start+t-1,
             load_scale=modelinfo.load_scale,
             ramp_scale=modelinfo.ramp_scale,
             corr_scale=modelinfo.corr_scale,

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -94,7 +94,7 @@ function OPFBlocks(
         data = opf_loaddata(
             rawdata;
             time_horizon_start=modelinfo.time_horizon_start + t - 1,
-            time_horizon_end=modelinfo.time_horizon_start+t-1,
+            time_horizon_end=modelinfo.time_horizon_start + t - 1,
             load_scale=modelinfo.load_scale,
             ramp_scale=modelinfo.ramp_scale,
             corr_scale=modelinfo.corr_scale,

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -53,7 +53,6 @@ function OPFBlocks(
     backend=JuMPBlockBackend,
     algparams::AlgParams = AlgParams(),
     comm::Union{MPI.Comm,Nothing},
-    genOff::Union{Dict{Int,Vector{Tuple{Int,Float64,Float64}}},Nothing} = nothing,
 )
     ngen  = length(opfdata.generators)
     nbus  = length(opfdata.buses)
@@ -80,7 +79,6 @@ function OPFBlocks(
         modelinfo,
         t, k;
         decompCtgs=false,
-        genOff::Union{Nothing,Vector{Tuple{Int,Float64,Float64}}}=nothing,
     )
         lineOff = Line()
         if length(rawdata.ctgs_arr) < k - 1
@@ -99,7 +97,6 @@ function OPFBlocks(
             ramp_scale=modelinfo.ramp_scale,
             corr_scale=modelinfo.corr_scale,
             lineOff=lineOff,
-            genOff=genOff,
         )
         return data
     end
@@ -115,14 +112,8 @@ function OPFBlocks(
                 @assert k > 0
                 localinfo.num_ctgs = 0
             end
-            _genOff = nothing
-            if genOff != nothing
-                _genOff = haskey(genOff,t) ? genOff[t] : nothing
-            end
             localdata = load_local_data(rawdata, opfdata, localinfo, t, k;
-                                        decompCtgs=algparams.decompCtgs,
-                                        genOff=_genOff,
-                                        )
+                                        decompCtgs=algparams.decompCtgs)
             # Create block model
             localmodel = backend(blk, localdata, rawdata, algparams, localinfo, t, k, T)
         else

--- a/src/params.jl
+++ b/src/params.jl
@@ -26,6 +26,7 @@ Specifies ProxAL's algorithmic parameters.
 | :--- | :--- | :--- |
 | `decompCtgs::Bool` | if true: decompose across contingencies (along with time) | false
 | `jacobi::Bool` |     if true: do Jacobi updates, else do Gauss-Siedel updates | true
+| `num_sweeps::Int` |  number of jacobi/gauss-seidel sweeps per primal update step | 1
 | `iterlim::Int` |     maximum number of ProxAL iterations | 100
 | `nlpiterlim::Int` |  maximum number of NLP subproblem iterations | 100
 | `tol::Float64` |     tolerance used for ProxAL termination | 1.0e-4
@@ -56,6 +57,7 @@ Specifies ProxAL's algorithmic parameters.
 Base.@kwdef mutable struct AlgParams
     decompCtgs::Bool = false # decompose contingencies (along with time)
     jacobi::Bool     = true  # if true: do jacobi, else do gauss-siedel
+    num_sweeps::Int  = 1     # Number of jacobi/gauss-seidel sweeps per primal update step
     iterlim::Int     = 100   # maximum number of ADMM iterations
     nlpiterlim::Int  = 100   # maximum number of NLP subproblem iterations
     tol::Float64     = 1e-3  # tolerance used for ADMM termination

--- a/src/params.jl
+++ b/src/params.jl
@@ -91,6 +91,7 @@ Specifies the ACOPF model structure.
 
 | Parameter | Description | Default value |
 | :--- | :--- | :--- |
+| `time_horizon_start::Int` | starting index of planning horizon | 1
 | `num_time_periods::Int` | number of time periods | 1
 | `num_ctgs::Int` | number of line contingencies | 0
 | `load_scale::Float64` | load multiplication factor | 1.0
@@ -109,6 +110,7 @@ Specifies the ACOPF model structure.
 | `ctgs_link_constr_type::Symbol` | `∈ [:frequency_penalty, :frequency_equality, :preventive_penalty, :preventive_equality, :corrective_penalty, :corrective_equality, :corrective_inequality]`, see [Formulation](@ref) | `:frequency_penalty`
 """
 Base.@kwdef mutable struct ModelInfo
+    time_horizon_start::Int = 1
     num_time_periods::Int = 1
     num_ctgs::Int = 0
     load_scale::Float64 = 1.0


### PR DESCRIPTION
* Allow planning horizon to start at arbitrary time index
* Read multiperiod load and renewable data from ACTIVSg time series format
* Set ramping values as per ExaGO toolkit
* Add a new algorithmic option (number of primal_update sweeps per ProxAL iteration)