### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -49,4 +49,5 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-buildpkg@latest
+      - run: source ./setup_moonshot.sh
       - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProxAL"
 uuid = "12c3852d-bf95-4e7b-be60-68937c3c927b"
 authors = ["Anirudh Subramanyam <asubramanyam@anl.gov>", "Youngdae Kim <youngdae@anl.gov>", "Francois Pacaud <fpacaud@anl.gov>", "Michel Schanen <mschanen@anl.gov>"]
-version = "0.5.3"
+version = "0.6.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -21,13 +21,13 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [compat]
 CUDA = "3.4"
 CatViews = "1"
-ExaAdmm = "0.1.2"
-ExaPF = "0.6"
-ExaTron = "1"
+ExaAdmm = "0.2"
+ExaPF = "0.8"
+ExaTron = "2.1"
 Ipopt = "1"
 JuMP = "1"
 MPI = "0.19"
-julia = "1.6"
+julia = "~1.7"
 
 [extras]
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"

--- a/src/ExaAdmmBackend/ExaAdmmBackend.jl
+++ b/src/ExaAdmmBackend/ExaAdmmBackend.jl
@@ -1,10 +1,9 @@
 module ExaAdmmBackend
 
+using CUDA
 import MPI
 import ExaAdmm
 import ExaTron
-
-using CUDA
 
 mutable struct ModelProxAL{T,TD,TI,TM} <: ExaAdmm.AbstractOPFModel{T,TD,TI,TM}
     # OPF's part

--- a/src/ExaAdmmBackend/proxal_admm_gpu.jl
+++ b/src/ExaAdmmBackend/proxal_admm_gpu.jl
@@ -52,7 +52,7 @@ function generator_kernel_two_level_proxal(ngen::Int, gen_start::Int,
             x[2] = min(xu[2], max(xl[2], s[I]))
             CUDA.sync_threads()
 
-            status, minor_iter = ExaTron.tron_qp_kernel(n, 500, 200, 1e-6, 1.0, x, xl, xu, A, c)
+            status, minor_iter = ExaTron.ExaTronCUDAKernels.tron_qp_kernel(n, 500, 200, 1e-6, 1.0, x, xl, xu, A, c)
 
             u[pg_idx] = x[1]
             s[I] = x[2]


### PR DESCRIPTION
Julia is set to `~1.7` as there is a KA/AMDGPU/CUDA unresolved issue https://github.com/JuliaGPU/KernelAbstractions.jl/pull/316 .